### PR TITLE
+ jsDelivr CDN info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ bower:
 bower install remarkable --save
 ```
 
+[jsDelivr CDN](http://www.jsdelivr.com/#!remarkable) for browser:
+```htm
+<script src="//cdn.jsdelivr.net/remarkable/{version}/remarkable.min.js"></script>
+```
+
 
 ## Usage
 


### PR DESCRIPTION
Would be nice if there was a build step to automatically insert the value for {version}, perhaps someday someone will write a [doc build script](http://verbiage.io/) ;).
