### PR TITLE
Add npm test command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   },
   "license": "MIT",
   "main": "index.js",
+  "scripts": {
+    "test": "make test"
+  },
   "dependencies": {
     "argparse": "~ 0.1.15",
     "autolinker": "~ 0.12.3",


### PR DESCRIPTION
It's a good common courtesy to allow people to `git clone; npm install; npm test` without trying to guess how repo internals are set up.
