### PR TITLE
rules must reference this.rules in renderInline

### DIFF
--- a/lib/renderer.js
+++ b/lib/renderer.js
@@ -296,10 +296,11 @@ function Renderer() {
 
 
 Renderer.prototype.renderInline = function (tokens, options) {
-  var result = '';
+  var result = '',
+      _rules = this.rules;
 
   for (var i = 0, len = tokens.length; i < len; i++) {
-    result += rules[tokens[i].type](tokens, i, options);
+    result += _rules[tokens[i].type](tokens, i, options);
   }
 
   return result;


### PR DESCRIPTION
today i wrote my first 'remarkable' extension (which can be studied here: https://gist.github.com/loveencounterflow/9d893beb37d12ad456fd). it looks like https://github.com/jonschlinkert/remarkable/blob/dev/lib/renderer.js#L293 should be patched so changes to the rules effected by `parser.use()` are properly reflected. 

may i also suggest to link my gist in your README.md until better documentation is available? the relevant issues are sort of hard to find and hard to piece together.
