### PR TITLE
Support pipe chars ("|") in table cells

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -117,7 +117,7 @@ module.exports = function table(state, startLine, endLine, silent) {
       state.tokens.push({ type: 'td_open', align: aligns[i], level: state.level++ });
       state.tokens.push({
         type: 'inline',
-        content: rows[i].replace(/\\|/,"|").replace(/^\|? *| *\|?$/g, ''),
+        content: rows[i].replace(/\\|/,'|').replace(/^\|? *| *\|?$/g, ''),
         level: state.level,
         children: []
       });


### PR DESCRIPTION
Fixes https://github.com/jonschlinkert/remarkable/issues/56
- Require that inner table pipes should be wrapped to spaces. 
- Added support for using pipe chars inside table cells by escaping them with backslash: "|" 
