### PR TITLE
Ruler.getRules falls back to empty object

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 benchmark/implementations/
 coverage/
-demo/sample.js
+demo/example.js
 dist/
 node_modules/

--- a/lib/ruler.js
+++ b/lib/ruler.js
@@ -263,7 +263,7 @@ Ruler.prototype.getRules = function (chainName) {
   if (this.__cache__ === null) {
     this.__compile__();
   }
-  return this.__cache__[chainName];
+  return this.__cache__[chainName] || {};
 };
 
 /**


### PR DESCRIPTION
This fixes an error I got disabling some rules, because it is not possible to read `length` of `undefined`:

```
TypeError: Cannot read property 'length' of undefined
    at Array.list [as 0] (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/rules_block/list.js:231:36)
    at ParserBlock.tokenize (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/parser_block.js:80:20)
    at ParserBlock.parse (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/parser_block.js:148:8)
    at Array.block [as 0] (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/rules_core/block.js:15:17)
    at Core.process (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/parser_core.js:50:13)
    at Remarkable.parse (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/index.js:138:13)
    at Remarkable.render (/Users/mhoffmann/Sites/amaphiko-web/node_modules/remarkable/lib/index.js:152:36)
    at React.createClass.render (/Users/mhoffmann/Sites/amaphiko-web/app/node_modules/components/text/index.jsx:39:25)
    at ReactCompositeComponentMixin._renderValidatedComponent (/Users/mhoffmann/Sites/amaphiko-web/node_modules/react/lib/ReactCompositeComponent.js:1260:34)
    at wrapper [as _renderValidatedComponent] (/Users/mhoffmann/Sites/amaphiko-web/node_modules/react/lib/ReactPerf.js:50:21)
```

Disabling these rules throws the error trying to render the remarkable demo:

```js
markdown.block.ruler.disable([
  'blockquote',
  'code',
  'fences',
  'hr',
  'table'
]);
markdown.inline.ruler.disable([
  'backticks',
  'del',
  'links'
]);
```