### PR TITLE
Option to not alter links provided for href

### DIFF
--- a/lib/helpers/parse_link_destination.js
+++ b/lib/helpers/parse_link_destination.js
@@ -74,7 +74,7 @@ module.exports = function parseLinkDestination(state, pos) {
 
   if (start === pos) { return false; }
 
-  link = normalizeLink(unescapeMd(state.src.slice(start, pos)));
+  link = unescapeMd(state.src.slice(start, pos));
   if (!state.parser.validateLink(link)) { return false; }
 
   state.linkContent = link;

--- a/lib/helpers/parse_link_destination.js
+++ b/lib/helpers/parse_link_destination.js
@@ -52,8 +52,7 @@ module.exports = function parseLinkDestination(state, pos) {
 
     if (code === 0x20) { break; }
 
-    // ascii control characters
-    if (code < 0x20 || code === 0x7F) { break; }
+    if (code > 0x08 && code < 0x0e) { break; }
 
     if (code === 0x5C /* \ */ && pos + 1 < max) {
       pos += 2;

--- a/test/fixtures/commonmark/good.txt
+++ b/test/fixtures/commonmark/good.txt
@@ -1564,7 +1564,7 @@ src line: 1854
 
 [αγω]
 .
-<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>
+<p><a href="/φου">αγω</a></p>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3361,7 +3361,7 @@ src line: 4026
 .
 [foo](/f&ouml;&ouml; "f&ouml;&ouml;")
 .
-<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
+<p><a href="/f&amp;ouml;&amp;ouml;" title="föö">foo</a></p>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3372,7 +3372,7 @@ src line: 4032
 
 [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
 .
-<p><a href="/f%C3%B6%C3%B6" title="föö">foo</a></p>
+<p><a href="/f&amp;ouml;&amp;ouml;" title="föö">foo</a></p>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -4529,7 +4529,7 @@ src line: 5179
 .
 [link](foo%20b&auml;)
 .
-<p><a href="foo%20b%C3%A4">link</a></p>
+<p><a href="foo%20b&amp;auml;">link</a></p>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -4538,7 +4538,7 @@ src line: 5189
 .
 [link]("title")
 .
-<p><a href="%22title%22">link</a></p>
+<p><a href="&quot;title&quot;">link</a></p>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/fixtures/remarkable/xss.txt
+++ b/test/fixtures/remarkable/xss.txt
@@ -30,7 +30,7 @@ Should not allow some protocols in links and images
 .
 [xss link](&#34;&#62;&#60;script&#62;alert&#40;&#34;xss&#34;&#41;&#60;/script&#62;)
 .
-<p><a href="%22%3E%3Cscript%3Ealert(%22xss%22)%3C/script%3E">xss link</a></p>
+<p><a href="&amp;#34;&amp;#62;&amp;#60;script&amp;#62;alert&amp;#40;&amp;#34;xss&amp;#34;&amp;#41;&amp;#60;/script&amp;#62;">xss link</a></p>
 .
 
 .


### PR DESCRIPTION
In my setup in markdown I initially provide values for hrefs as token markers, which after html is resolved to DOM are replaced with accurate links.

Unfortunately it can't work with how currently remarkable resolves html, as `[text](link)` doesn't resolve to `<a href="">text</a>`, if _link_ is not seen as valid URL.

I believe it should be more agnostic to user input.

Problem lies in following parts:

1. It should pass through space or control characters in links (e.g. I use control characters as markers).
So following should be removed:
https://github.com/jonschlinkert/remarkable/blob/f1de27b203eb4e169ed40954061b76f0803b14e7/lib/helpers/parse_link_destination.js#L53-L56

2. It should not normalize link texts. Naturally valid url should be provided. For that  _normalizeLink_ call should not take place here:
https://github.com/jonschlinkert/remarkable/blob/f1de27b203eb4e169ed40954061b76f0803b14e7/lib/helpers/parse_link_destination.js#L78

I can provide a pull request that addresses that, but first I would like to know, wether you're ok with such change