### PR TITLE
Fix "Manage rules" sample code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,14 +199,14 @@ md = new Remarkable('full', {
 // Manually enable rules, disabled by default:
 //
 var md = new Remarkable();
-md.block.ruler.core([
+md.core.ruler.enable([
   'abbr'
 ]);
 md.block.ruler.enable([
   'footnote',
   'deflist'
 ]);
-md.block.ruler.enable([
+md.inline.ruler.enable([
   'footnote_inline',
   'ins',
   'mark',


### PR DESCRIPTION
The sample code in "Manage rules" section of README.md seems to be broken.

- `md.block.ruler.core` results in `Object #<Ruler> has no method 'core'`.
  It should be `md.core.ruler.enable`.
- The second `md.block.ruler.enable` results in `Rules manager: invalid rule name footnote_inline`.
  It should be `md.inline.ruler.enable`.

This Pull Request fixes that.