### PR TITLE
Fix missing space after shortcut links

### DIFF
--- a/lib/rules_inline/links.js
+++ b/lib/rules_inline/links.js
@@ -118,7 +118,12 @@ module.exports = function links(state, silent) {
 
     // covers label === '' and label === undefined
     // (collapsed reference link and shortcut reference link respectively)
-    if (!label) { label = state.src.slice(labelStart, labelEnd); }
+    if (!label) {
+      if (typeof label === 'undefined') {
+        pos = labelEnd + 1;
+      }
+      label = state.src.slice(labelStart, labelEnd);
+    }
 
     ref = state.env.references[normalizeReference(label)];
     if (!ref) {

--- a/test/fixtures/remarkable/commonmark_extras.txt
+++ b/test/fixtures/remarkable/commonmark_extras.txt
@@ -132,3 +132,20 @@ Should not throw exception on mailformed URI
 .
 <p><a href="%25test">foo</a></p>
 .
+
+
+Issue #160:
+
+.
+Hello [google] where are you?
+
+Hello [google][] where are you?
+
+Hello [google]  [] where are you?
+
+[google]: https://google.com
+.
+<p>Hello <a href="https://google.com">google</a> where are you?</p>
+<p>Hello <a href="https://google.com">google</a> where are you?</p>
+<p>Hello <a href="https://google.com">google</a> where are you?</p>
+.


### PR DESCRIPTION
This patch adds missing whitespace after shortcut links.

Close #160.