### PR TITLE
define bin script for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "test": "make test"
   },
+  "bin": "./bin/remarkable.js",
   "dependencies": {
     "argparse": "~0.1.15",
     "autolinker": "~0.15.0"


### PR DESCRIPTION
So that remarkable can be used as a CLI program.