### PR TITLE
StateBlock.getLines should only read from the current line

### DIFF
--- a/lib/rules_block/state_block.js
+++ b/lib/rules_block/state_block.js
@@ -128,7 +128,7 @@ StateBlock.prototype.getLines = function getLines(begin, end, indent, keepLastLF
   // Opt: don't use push queue for single line;
   if (line + 1 === end) {
     first = this.bMarks[line] + Math.min(this.tShift[line], indent);
-    last = keepLastLF ? this.bMarks[end] : this.eMarks[end - 1];
+    last = keepLastLF ? this.bMarks[line] : this.eMarks[line - 1];
     return this.src.slice(first, last);
   }
 

--- a/lib/rules_block/state_block.js
+++ b/lib/rules_block/state_block.js
@@ -128,7 +128,7 @@ StateBlock.prototype.getLines = function getLines(begin, end, indent, keepLastLF
   // Opt: don't use push queue for single line;
   if (line + 1 === end) {
     first = this.bMarks[line] + Math.min(this.tShift[line], indent);
-    last = keepLastLF ? this.bMarks[line] : this.eMarks[line - 1];
+    last = keepLastLF ? this.eMarks[line] + 1 : this.eMarks[line];
     return this.src.slice(first, last);
   }
 


### PR DESCRIPTION
This is to fix issue #174.

StateBlock.getLines should not read through the second line when handling single line case.