### PR TITLE
Image alt should be unescaped

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -167,7 +167,7 @@ rules.link_close = function (/* tokens, idx, options, env */) {
 rules.image = function (tokens, idx, options /*, env */) {
   var src = ' src="' + escapeHtml(tokens[idx].src) + '"';
   var title = tokens[idx].title ? (' title="' + escapeHtml(replaceEntities(tokens[idx].title)) + '"') : '';
-  var alt = ' alt="' + (tokens[idx].alt ? escapeHtml(replaceEntities(tokens[idx].alt)) : '') + '"';
+  var alt = ' alt="' + (tokens[idx].alt ? escapeHtml(replaceEntities(unescapeMd(tokens[idx].alt))) : '') + '"';
   var suffix = options.xhtmlOut ? ' /' : '';
   return '<img' + src + alt + title + suffix + '>';
 };

--- a/test/fixtures/remarkable/commonmark_extras.txt
+++ b/test/fixtures/remarkable/commonmark_extras.txt
@@ -149,3 +149,14 @@ Hello [google]  [] where are you?
 <p>Hello <a href="https://google.com">google</a> where are you?</p>
 <p>Hello <a href="https://google.com">google</a> where are you?</p>
 .
+
+
+Image alt should be unescaped
+
+.
+[Foo\\bar\]]: /url
+
+![Foo\\bar\]]
+.
+<p><img src="/url" alt="Foo\bar]"></p>
+.


### PR DESCRIPTION
I compared output from remarkable with http://spec.commonmark.org/dingus/ and apparently alt in images should be escaped.

So output of this code:
```
[Foo\\bar\]]: /url

![Foo\\bar\]]
```
Should be:
```
<p><img src="/url" alt="Foo\bar]"></p>
```
But currently it is:
```
<p><img src="/url" alt="Foo\\bar\]"></p>
```
