### PR TITLE
Support for specifying link target

### DIFF
--- a/demo/assets/index.js
+++ b/demo/assets/index.js
@@ -9,6 +9,7 @@
     breaks:       false,        // Convert '\n' in paragraphs into <br>
     langPrefix:   'language-',  // CSS language prefix for fenced blocks
     linkify:      true,         // autoconvert URL-like texts to links
+    linkTarget:   '',           // set target to open link in
     typographer:  true,         // Enable smartypants and other sweet transforms
 
     // options below are for demo only

--- a/demo/example.js
+++ b/demo/example.js
@@ -7,6 +7,7 @@ var md = new Remarkable('full', {
   breaks:       false,        // Convert '\n' in paragraphs into <br>
   langPrefix:   'language-',  // CSS language prefix for fenced blocks
   linkify:      true,         // autoconvert URL-like texts to links
+  linkTarget:   '',           // set target to open link in
 
   // Enable some language-neutral replacements + quotes beautification
   typographer:  false,

--- a/demo/index.jade
+++ b/demo/index.jade
@@ -66,6 +66,12 @@ html
           label._tip(title='autoconvert link-like texts to links')
             input#linkify(type='checkbox')
             |  linkify
+        .form-group.not-strict
+          input#linkTarget.form-control._tip(
+          type='input'
+          placeholder='link target'
+          title='target to open link in'
+          )
         .checkbox.not-strict
           label._tip(title='do typographyc replacements, (c) -> © and so on')
             input#typographer(type='checkbox')

--- a/lib/configs/commonmark.js
+++ b/lib/configs/commonmark.js
@@ -10,6 +10,7 @@ module.exports = {
     breaks:       false,        // Convert '\n' in paragraphs into <br>
     langPrefix:   'language-',  // CSS language prefix for fenced blocks
     linkify:      false,        // autoconvert URL-like texts to links
+    linkTarget:   '',           // set target to open link in
 
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,

--- a/lib/configs/default.js
+++ b/lib/configs/default.js
@@ -10,6 +10,7 @@ module.exports = {
     breaks:       false,        // Convert '\n' in paragraphs into <br>
     langPrefix:   'language-',  // CSS language prefix for fenced blocks
     linkify:      false,        // autoconvert URL-like texts to links
+    linkTarget:   '',           // set target to open link in
 
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,

--- a/lib/configs/full.js
+++ b/lib/configs/full.js
@@ -10,6 +10,7 @@ module.exports = {
     breaks:       false,        // Convert '\n' in paragraphs into <br>
     langPrefix:   'language-',  // CSS language prefix for fenced blocks
     linkify:      false,        // autoconvert URL-like texts to links
+    linkTarget:   '',           // set target to open link in
 
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,22 +24,22 @@ var config = {
 /**
  * The `StateCore` class manages state.
  *
- * @param {Object} `self` Remarkable instance
+ * @param {Object} `instance` Remarkable instance
  * @param {String} `str` Markdown string
  * @param {Object} `env`
  */
 
-function StateCore(self, str, env) {
+function StateCore(instance, str, env) {
   this.src = str;
   this.env = env;
-  this.options = self.options;
+  this.options = instance.options;
   this.tokens = [];
   this.inlineMode = false;
 
-  this.inline = self.inline;
-  this.block = self.block;
-  this.renderer = self.renderer;
-  this.typographer = self.typographer;
+  this.inline = instance.inline;
+  this.block = instance.block;
+  this.renderer = instance.renderer;
+  this.typographer = instance.typographer;
 }
 
 /**

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -152,9 +152,10 @@ rules.paragraph_close = function (tokens, idx /*, options, env */) {
  * Links
  */
 
-rules.link_open = function (tokens, idx /*, options, env */) {
+rules.link_open = function (tokens, idx, options /* env */) {
   var title = tokens[idx].title ? (' title="' + escapeHtml(replaceEntities(tokens[idx].title)) + '"') : '';
-  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + '>';
+  var target = options.linkTarget ? (' target="' + options.linkTarget + '"') : '';
+  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + '>';
 };
 rules.link_close = function (/* tokens, idx, options, env */) {
   return '</a>';

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -42,7 +42,7 @@ rules.code = function (tokens, idx /*, options, env */) {
  * Fenced code blocks
  */
 
-rules.fence = function (tokens, idx, options, env, self) {
+rules.fence = function (tokens, idx, options, env, instance) {
   var token = tokens[idx];
   var langClass = '';
   var langPrefix = options.langPrefix;
@@ -60,8 +60,8 @@ rules.fence = function (tokens, idx, options, env, self) {
 
     fenceName = token.params.split(/\s+/g)[0];
 
-    if (has(self.rules.fence_custom, fenceName)) {
-      return self.rules.fence_custom[fenceName](tokens, idx, options, env, self);
+    if (has(instance.rules.fence_custom, fenceName)) {
+      return instance.rules.fence_custom[fenceName](tokens, idx, options, env, instance);
     }
 
     langName = escapeHtml(replaceEntities(unescapeMd(fenceName)));

--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -28,7 +28,7 @@ function createLinkifier() {
     url: true,
     email: true,
     twitter: false,
-    replaceFn: function (autolinker, match) {
+    replaceFn: function (linker, match) {
       // Only collect matched strings but don't change anything.
       switch (match.getType()) {
         /*eslint default-case:0*/

--- a/support/demodata.js
+++ b/support/demodata.js
@@ -10,8 +10,8 @@ var path = require('path');
 console.log(JSON.stringify({
   self: {
     demo: {
-      code:   fs.readFileSync(path.join(__dirname, '../demo/sample.js'), 'utf8'),
-      source: fs.readFileSync(path.join(__dirname, '../demo/sample.md'), 'utf8')
+      code:   fs.readFileSync(path.join(__dirname, '../demo/example.js'), 'utf8'),
+      source: fs.readFileSync(path.join(__dirname, '../demo/example.md'), 'utf8')
     }
   }
 }, null, 2));

--- a/test/misc.js
+++ b/test/misc.js
@@ -183,6 +183,37 @@ describe('Links validation', function () {
 
 });
 
+describe('Link target', function () {
+
+  it('Should not have target when linkTarget is not defined', function () {
+    var md = new Remarkable();
+
+    assert.strictEqual(
+      md.render('[test](http://example.com)'),
+      '<p><a href="http://example.com">test</a></p>\n'
+    );
+  });
+
+  it('Should not have target when linkTarget is empty', function () {
+    var md = new Remarkable({ linkTarget: '' });
+
+    assert.strictEqual(
+      md.render('[test](http://example.com)'),
+      '<p><a href="http://example.com">test</a></p>\n'
+    );
+  });
+
+  it('Should add target to link when linkTarget is specified in options', function () {
+    var md = new Remarkable({ linkTarget: '_blank' });
+
+    assert.strictEqual(
+      md.render('[test](http://example.com)'),
+      '<p><a href="http://example.com" target="_blank">test</a></p>\n'
+    );
+  });
+
+});
+
 
 describe('Custom fences', function () {
 

--- a/test/misc.js
+++ b/test/misc.js
@@ -75,7 +75,7 @@ describe('API', function () {
   it('plugin', function () {
     var succeeded = false;
 
-    function plugin(self, opts) { if (opts === 'bar') { succeeded = true; } }
+    function plugin(instance, opts) { if (opts === 'bar') { succeeded = true; } }
 
     var md = new Remarkable();
 
@@ -189,10 +189,10 @@ describe('Custom fences', function () {
   it('should render differently overriden rule', function () {
     var md = new Remarkable();
 
-    md.renderer.rules.fence_custom.foo = function (tokens, idx, options, env, self) {
+      md.renderer.rules.fence_custom.foo = function (tokens, idx, options, env, instance) {
       return '<div class="foo">' +
              utils.escapeHtml(tokens[idx].content) +
-             '</div>' + self.getBreak(tokens, idx);
+             '</div>' + instance.getBreak(tokens, idx);
     };
 
     var text = '```foo bar\n' +


### PR DESCRIPTION
Adds supports for specifying link target and resolves issue #171

This also corrects some lint errors and completes renaming from samle -> example in demo files