### PR TITLE
#187 allow no block rules

### DIFF
--- a/lib/rules_block/paragraph.js
+++ b/lib/rules_block/paragraph.js
@@ -12,7 +12,7 @@ module.exports = function paragraph(state, startLine/*, endLine*/) {
 
   // jump line-by-line until empty one or EOF
   if (nextLine < endLine && !state.isEmpty(nextLine)) {
-    terminatorRules = state.parser.ruler.getRules('paragraph');
+    terminatorRules = state.parser.ruler.getRules('paragraph') || [];
 
     for (; nextLine < endLine && !state.isEmpty(nextLine); nextLine++) {
       // this would be a code block normally, but after paragraph


### PR DESCRIPTION
 If no paragraph rules exist, default ot empty array instead of undefined
