### PR TITLE
Fixed use of argparse so --file is available.

### DIFF
--- a/bin/remarkable.js
+++ b/bin/remarkable.js
@@ -17,7 +17,7 @@ var cli = new argparse.ArgumentParser({
   addHelp: true
 });
 
-cli.addArgument([ 'file' ], {
+cli.addArgument([ '--file' ], {
   help: 'File to read',
   nargs: '?',
   defaultValue: '-'


### PR DESCRIPTION
Simple fix for `--file` not working.