### PR TITLE
Make sure getRule always returns an array (fixes #187)

### DIFF
--- a/lib/ruler.js
+++ b/lib/ruler.js
@@ -263,7 +263,7 @@ Ruler.prototype.getRules = function (chainName) {
   if (this.__cache__ === null) {
     this.__compile__();
   }
-  return this.__cache__[chainName];
+  return this.__cache__[chainName] || [];
 };
 
 /**

--- a/test/ruler.js
+++ b/test/ruler.js
@@ -132,4 +132,11 @@ describe('Ruler', function () {
     });
   });
 
+  it('should always return an array, even when no rules are defined for the rule name', function () {
+    var rules, ruler = new Ruler();
+
+    rules = ruler.getRules('list');
+    assert.strictEqual(rules.constructor, Array);
+  });
+
 });


### PR DESCRIPTION
A lot of places in remarkable call getRules and expect an array back, and don't handle the case of when they get undefined instead.