### PR TITLE
Expose most of the typical options as arguments for use on the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ If installed globally with `npm`:
 
 ```sh
 cat myfile.md | remarkable 
-remarkable --file myfile.md
+remarkable myfile.md
 
 # get options
 remarkable -h

--- a/bin/remarkable.js
+++ b/bin/remarkable.js
@@ -92,7 +92,7 @@ readFile(options.file, 'utf8', function (err, input) {
   };
 
   if (options.highlight) {
-  	var hljs;
+    var hljs;
 
     try {
       hljs = require('highlight.js');

--- a/bin/remarkable.js
+++ b/bin/remarkable.js
@@ -88,14 +88,16 @@ readFile(options.file, 'utf8', function (err, input) {
     html: options.no_html ? false : true,
     breaks: options.breaks ? true : false,
     linkify: options.no_linkify ? false : true,
-    typographer: options.no_typographer ? false : true,
+    typographer: options.no_typographer ? false : true
   };
 
-  if ( options.highlight ) {
+  if (options.highlight) {
+  	var hljs;
+
     try {
-      var hljs = require('highlight.js');
+      hljs = require('highlight.js');
     } catch (e) {
-      console.error("highlight.js could not be loaded. Please make sure it is installed before using --highlight");
+      console.error('highlight.js could not be loaded. Please make sure it is installed before using --highlight');
       process.exit(1);
     }
 
@@ -103,15 +105,15 @@ readFile(options.file, 'utf8', function (err, input) {
       if (lang && hljs.getLanguage(lang)) {
         try {
           return hljs.highlight(lang, str).value;
-        } catch (err) {}
+        } catch (e) {}
       }
 
       try {
         return hljs.highlightAuto(str).value;
-      } catch (err) {}
+      } catch (e) {}
 
       return ''; // use external default escaping
-    }
+    };
   }
 
   md = new Remarkable('full', mdopts);

--- a/bin/remarkable.js
+++ b/bin/remarkable.js
@@ -18,9 +18,34 @@ var cli = new argparse.ArgumentParser({
 });
 
 cli.addArgument([ 'file' ], {
-  help: 'File to read',
+  help: 'File to read (Defaults to standard input)',
   nargs: '?',
   defaultValue: '-'
+});
+
+cli.addArgument([ '--no-html' ], {
+  help: 'Escape HTML tags in source',
+  nargs: 0
+});
+
+cli.addArgument([ '--breaks' ], {
+  help: 'Convert \'\\n\' in paragraphs into <br>',
+  nargs: 0
+});
+
+cli.addArgument([ '--no-linkify' ], {
+  help: 'Disable autoconverting of URL-like text',
+  nargs: 0
+});
+
+cli.addArgument([ '--no-typographer' ], {
+  help: 'Disable typographic marks replacement and smart quotes',
+  nargs: 0
+});
+
+cli.addArgument([ '--highlight' ], {
+  help: 'Enable syntax highlighting for fenced blocks (Requires highlight.js be installed)',
+  nargs: 0
 });
 
 var options = cli.parseArgs();
@@ -59,12 +84,37 @@ readFile(options.file, 'utf8', function (err, input) {
     process.exit(1);
   }
 
-  md = new Remarkable('full', {
-    html: true,
-    xhtmlOut: true,
-    typographer: true,
-    linkify: true
-  });
+  var mdopts = {
+    html: options.no_html ? false : true,
+    breaks: options.breaks ? true : false,
+    linkify: options.no_linkify ? false : true,
+    typographer: options.no_typographer ? false : true,
+  };
+
+  if ( options.highlight ) {
+    try {
+      var hljs = require('highlight.js');
+    } catch (e) {
+      console.error("highlight.js could not be loaded. Please make sure it is installed before using --highlight");
+      process.exit(1);
+    }
+
+    mdopts.highlight = function (str, lang) {
+      if (lang && hljs.getLanguage(lang)) {
+        try {
+          return hljs.highlight(lang, str).value;
+        } catch (err) {}
+      }
+
+      try {
+        return hljs.highlightAuto(str).value;
+      } catch (err) {}
+
+      return ''; // use external default escaping
+    }
+  }
+
+  md = new Remarkable('full', mdopts);
 
   try {
     output = md.render(input);


### PR DESCRIPTION
The CLI is handy but I found I wanted a bit more control. Added five options, just simple flags, to mimic most of what I found on the demo page.

I didn't change the package dependencies to add highlight.js but instead exit with a reasonable error message if the user tries to use it without being installed. Not sure if that was the right approach. If not just let me know what I should do instead.

Oh, and I also removed `--file` from the example in the README.md since that didn't work and seemed likely a typo. I saw the pull request https://github.com/jonschlinkert/remarkable/pull/200 to change it so `--file` did work but that doesn't seem like the right approach to me.

Below is what `remarkable -h` shows now as a quick example of what I did. Thanks!

```
usage: remarkable [-h] [-v] [--no-html] [--breaks] [--no-linkify]
                  [--no-typographer] [--highlight]
                  [file]

Positional arguments:
  file              File to read (Defaults to standard input)

Optional arguments:
  -h, --help        Show this help message and exit.
  -v, --version     Show program's version number and exit.
  --no-html         Escape HTML tags in source
  --breaks          Convert '\n' in paragraphs into <br>
  --no-linkify      Disable autoconverting of URL-like text
  --no-typographer  Disable typographic marks replacement and smart quotes
  --highlight       Enable syntax highlighting for fenced blocks (Requires
                    highlight.js be installed)
```