### PR TITLE
support passthrough classes

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -70,7 +70,8 @@ rules.fence = function (tokens, idx, options, env, instance) {
   }
 
   if (options.highlight) {
-    highlighted = options.highlight(token.content, langName) || escapeHtml(token.content);
+    highlighted = options.highlight.apply(options.highlight, [ token.content ].concat(fences))
+      || escapeHtml(token.content);
   } else {
     highlighted = escapeHtml(token.content);
   }

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -46,7 +46,7 @@ rules.fence = function (tokens, idx, options, env, instance) {
   var token = tokens[idx];
   var langClass = '';
   var langPrefix = options.langPrefix;
-  var langName = '', fenceName;
+  var langName = '', fences, fenceName;
   var highlighted;
 
   if (token.params) {
@@ -58,10 +58,11 @@ rules.fence = function (tokens, idx, options, env, instance) {
     // for diagrams, latex, and any other fenced block with custom look
     //
 
-    fenceName = token.params.split(/\s+/g)[0];
+    fences = token.params.split(/\s+/g);
+    fenceName = fences.join(' ');
 
-    if (has(instance.rules.fence_custom, fenceName)) {
-      return instance.rules.fence_custom[fenceName](tokens, idx, options, env, instance);
+    if (has(instance.rules.fence_custom, fences[0])) {
+      return instance.rules.fence_custom[fences[0]](tokens, idx, options, env, instance);
     }
 
     langName = escapeHtml(replaceEntities(unescapeMd(fenceName)));

--- a/test/fixtures/commonmark/good.txt
+++ b/test/fixtures/commonmark/good.txt
@@ -1172,13 +1172,13 @@ end
 src line: 1417
 
 .
-~~~~    ruby startline=3 $%@#$
+~~~~    ruby startline=3 $%@#$  ruby-example
 def foo(x)
   return 3
 end
 ~~~~~~~
 .
-<pre><code class="language-ruby">def foo(x)
+<pre><code class="language-ruby startline=3 $%@#$ ruby-example">def foo(x)
   return 3
 end
 </code></pre>


### PR DESCRIPTION
Support passing multiple languages to code blocks. This will enable examples and other sorts of groupings that currently aren't possible. Here's some examples:

**Switches based on selected language** 

```
<backticks> js example-1
console.log('hello world!')
</backticks>

<backticks> php example-1
echo "hello world!";
</backticks>
```

**Allowing some scripts to execute for interactive examples**

```md
<backticks> js allow-run
console.log('hello world!')
</backticks>
```