### PR TITLE
Add option to overwrite the default prefilter for links

### DIFF
--- a/lib/configs/commonmark.js
+++ b/lib/configs/commonmark.js
@@ -12,6 +12,13 @@ module.exports = {
     linkify:      false,        // autoconvert URL-like texts to links
     linkTarget:   '',           // set target to open link in
 
+    // linkifyPrefilter. Function that overwrite the default link prefilter,
+    // specified by this regex: /www|@|\:\/\//
+    //
+    // @param { string } link that will be tested.
+    // @returns { Boolean } whether or not the link passes the prefilter.
+    linkifyPrefilter: null,
+
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,
 

--- a/lib/configs/default.js
+++ b/lib/configs/default.js
@@ -12,6 +12,13 @@ module.exports = {
     linkify:      false,        // autoconvert URL-like texts to links
     linkTarget:   '',           // set target to open link in
 
+    // linkifyPrefilter. Function that overwrite the default link prefilter,
+    // specified by this regex: /www|@|\:\/\//
+    //
+    // @param { string } link that will be tested.
+    // @returns { Boolean } whether or not the link passes the prefilter.
+    linkifyPrefilter: null,
+
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,
 

--- a/lib/configs/full.js
+++ b/lib/configs/full.js
@@ -12,6 +12,13 @@ module.exports = {
     linkify:      false,        // autoconvert URL-like texts to links
     linkTarget:   '',           // set target to open link in
 
+    // linkifyPrefilter. Function that overwrite the default link prefilter,
+    // specified by this regex: /www|@|\:\/\//
+    //
+    // @param { string } link that will be tested.
+    // @returns { Boolean } whether or not the link passes the prefilter.
+    linkifyPrefilter: null,
+
     // Enable some language-neutral replacements + quotes beautification
     typographer:  false,
 

--- a/lib/rules_core/linkify.js
+++ b/lib/rules_core/linkify.js
@@ -95,7 +95,14 @@ module.exports = function linkify(state) {
       }
       if (htmlLinkLevel > 0) { continue; }
 
-      if (token.type === 'text' && LINK_SCAN_RE.test(token.content)) {
+      var linkifyPrefilter = state.options.linkifyPrefilter;
+      var passPrefilter = LINK_SCAN_RE.test(token.content);
+      if (linkifyPrefilter && typeof linkifyPrefilter === 'function') {
+        // Use the custom prefilter for links.
+        passPrefilter = linkifyPrefilter(token.content);
+      }
+
+      if (token.type === 'text' && passPrefilter) {
 
         // Init linkifier in lazy manner, only if required.
         if (!linkifier) {


### PR DESCRIPTION
This PR intents to fix some issues a few users have been having. For example, #183 and #134. The current implementation also won't linkify some valid links, like just "github.com".

What I did is introduce a new `linkifyPrefilter` option, which lets the user to write their own prefilter, instead of the [default prefilter](https://github.com/jonschlinkert/remarkable/blob/master/lib/rules_core/linkify.js#L11). The user could also make the function to `return true` if he/she wants to disable the prefilter.

I haven't written any test yet, but I'll be placed to do it if you agree with this PR.

This PR fixes #183.