### PR TITLE
Fix missing punctuation

### DIFF
--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -5,7 +5,7 @@
 
 var QUOTE_TEST_RE = /['"]/;
 var QUOTE_RE = /['"]/g;
-var PUNCT_RE = /[-\s()\[\]]/;
+var PUNCT_RE = /[-\s()\[\]\.\,]/;
 var APOSTROPHE = '’';
 
 // This function returns true if the character at `pos`

--- a/lib/rules_core/smartquotes.js
+++ b/lib/rules_core/smartquotes.js
@@ -5,7 +5,7 @@
 
 var QUOTE_TEST_RE = /['"]/;
 var QUOTE_RE = /['"]/g;
-var PUNCT_RE = /[-\s()\[\]\.\,]/;
+var PUNCT_RE = /[-\s()\[\]\.\,\;]/;
 var APOSTROPHE = '’';
 
 // This function returns true if the character at `pos`


### PR DESCRIPTION
I've found out that dot and comma are missing on the punctuation list. That makes Remarkable skip sequences like ". for instance.

![Remarkable](https://ooo.0o0.ooo/2017/02/24/58afdfe8f253a.png)