### PR TITLE
fix missing hash when linkify urls with unicode characaters

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "argparse": "~0.1.15",
-    "autolinker": "~0.15.0"
+    "autolinker": "~0.28.0"
   },
   "devDependencies": {
     "ansi": "^0.3.0",

--- a/test/fixtures/remarkable/linkify.txt
+++ b/test/fixtures/remarkable/linkify.txt
@@ -46,6 +46,13 @@ www.example.org版权所有
 .
 
 
+unicode
+.
+www.example.org#版权所有
+.
+<p><a href="http://www.example.org#版权所有">www.example.org#版权所有</a></p>
+.
+
 emails
 .
 test@example.com


### PR DESCRIPTION
this is a bug of autolinker, which is fixed in 0.24:
https://github.com/gregjacobs/Autolinker.js/releases/tag/0.24.0