### PR TITLE
Fix README typo in subscript example

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Enabled by default:
 Disabled by default:
 
 - [\<sup>](http://johnmacfarlane.net/pandoc/README.html#superscripts-and-subscripts) - `19^th^`
-- [\<sub>](http://johnmacfarlane.net/pandoc/README.html#superscripts-and-subscripts) - `H~2~0`
+- [\<sub>](http://johnmacfarlane.net/pandoc/README.html#superscripts-and-subscripts) - `H~2~O`
 - [abbreviations](https://michelf.ca/projects/php-markdown/extra/#abbr)
 - __\<ins>__ - `++inserted text++` (experimental)
 - __\<mark>__ - `==marked text==` (experimental)


### PR DESCRIPTION
In the chemical formula for water, H<sub>2</sub>O, commonly pronounced _H “two-oh,”_ the “oh” is the letter _O_ for Oxygen, not a zero 🙂 