### PR TITLE
Remove Bad Apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ Sample: spec.txt (110610 bytes)
  > marked-0.3.2 x 22.92 ops/sec ±0.79% (41 runs sampled)
 ```
 
-As you can see, `remarkable` doesn't pay with speed for it's flexibility. Because
+As you can see, `remarkable` doesn't pay with speed for its flexibility. Because
 it's written in monomorphic style and uses JIT inline caches effectively.
 
 


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!