### PR TITLE
Open external links using rel="noopener"

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -157,7 +157,8 @@ rules.paragraph_close = function(tokens, idx /*, options, env */) {
 rules.link_open = function(tokens, idx, options /* env */) {
   var title = tokens[idx].title ? (' title="' + escapeHtml(replaceEntities(tokens[idx].title)) + '"') : '';
   var target = options.linkTarget ? (' target="' + options.linkTarget + '"') : '';
-  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + '>';
+  var rel = options.linkTarget && options.linkTarget !== '_self' ? (' rel="noopener"') : '';
+  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + rel + '>';
 };
 rules.link_close = function(/* tokens, idx, options, env */) {
   return '</a>';


### PR DESCRIPTION
For performance and security reasons, this patch opens external links using `rel="noopener"` when target is defined and other than `_self`.

More details about the reason for this patch are available below:

https://developers.google.com/web/tools/lighthouse/audits/noopener