### PR TITLE
Allow ordered lists to start with 0

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -131,7 +131,7 @@ rules.list_item_close = function (/* tokens, idx, options, env */) {
 
 rules.ordered_list_open = function (tokens, idx /*, options, env */) {
   var token = tokens[idx];
-  var order = token.order > 1 ? ' start="' + token.order + '"' : '';
+  var order = (token.order === 0 || token.order > 1) ? ' start="' + token.order + '"' : '';
   return '<ol' + order + '>\n';
 };
 rules.ordered_list_close = function (tokens, idx /*, options, env */) {


### PR DESCRIPTION
Previously, ordered lists starting with 0 were rendered starting at 1. Starting ordered lists with 0 is explicitly allowed by the CommonMark spec, see https://spec.commonmark.org/0.28/#example-230.

Expected:
``` js
> var Remarkable = require('remarkable');
> var md = new Remarkable();
> console.log(md.render("0. ok"));
  <ol start="0">
  <li>ok</li>
  </ol>
```

Before fix:
``` js
> var Remarkable = require('remarkable');
> var md = new Remarkable();
> console.log(md.render("0. ok"));
  <ol>
  <li>ok</li>
  </ol>
```