### PR TITLE
fix infinite loop caused by comment regexp in htmltag module

### DIFF
--- a/lib/common/html_re.js
+++ b/lib/common/html_re.js
@@ -41,7 +41,7 @@ var open_tag    = replace(/<[A-Za-z][A-Za-z0-9]*attribute*\s*\/?>/)
                     ();
 
 var close_tag   = /<\/[A-Za-z][A-Za-z0-9]*\s*>/;
-var comment     = /<!--([^-]+|[-][^-]+)*-->/;
+var comment     = /<!--[\s\S]*?-->/;
 var processing  = /<[?].*?[?]>/;
 var declaration = /<![A-Z]+\s+[^>]*>/;
 var cdata       = /<!\[CDATA\[([^\]]+|\][^\]]|\]\][^>])*\]\]>/;


### PR DESCRIPTION
I don't know why comment regexp looks like this: `/<!--([^-]+|[-][^-]+)*-->/`, maybe for some specific rules.

But I found that `/<!--([^-]+|[-][^-]+)*-->/` can't match something like this: `<!-- a--z -->`, which is obviously a html comment.

More importantly, this regexp `/<!--([^-]+|[-][^-]+)*-->/` may cause infinite loop and break down the browser.

See [my issue](https://github.com/jonschlinkert/remarkable/issues/305) before.

I positioned the bug, but have no idea why this regexp should cause infinite loop.

I rewrite it to `/<!--[\s\S]*?-->/` and make this pull request.