### PR TITLE
Add the `langPrefix` option to the highlight syntax example

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ var hljs       = require('highlight.js') // https://highlightjs.org/
 
 // Actual default values
 var md = new Remarkable({
+  langPrefix: 'hljs language-',
   highlight: function (str, lang) {
     if (lang && hljs.getLanguage(lang)) {
       try {
@@ -180,6 +181,7 @@ var md = new Remarkable({
 });
 ```
 
+The `langPrefix` option is required to pass the `hljs` class to the code block so that the full Highlight.js styles are applied correctly. Note that it will only work if [your fenced code block has params set, like a language param](https://github.com/jonschlinkert/remarkable/issues/224#issuecomment-339686207).
 
 ### Syntax extensions
 


### PR DESCRIPTION
Per [this issue](https://github.com/jonschlinkert/remarkable/issues/224), syntax highlighting with Highlight.js doesn't really work unless that `hljs` class is applied to the code block, so I figured it was better to put it in the example in the docs since it seems necessary to every implementation.