### PR TITLE
Updated argparse package reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "argparse": "~1.10.10",
+    "argparse": "~1.0.10",
     "autolinker": "~0.28.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "argparse": "~0.1.15",
+    "argparse": "~1.10.10",
     "autolinker": "~0.28.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Version of argparse being referenced is very old and has a security vulnerability via an old reference to underscore.  argparse has been using lodash for a very long time which alleviates the vulnerability. 

https://app.snyk.io/vuln/npm:underscore.string:20170908