### PR TITLE
argparse@1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "argparse": "~0.1.15",
+    "argparse": "~1.0.10",
     "autolinker": "~0.28.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates `argparse` dependency to avoid security report (argparse used to depend on underscore and now uses lodash).

https://nodesecurity.io/advisories/745