### PR TITLE
Defend against undefined reference variable in inline links module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - node
-  - '6'
-  - '0.10'
-  - '0.12'
-  - 4
-  - 6
+  - "6"
 script: make test-ci

--- a/lib/rules_inline/links.js
+++ b/lib/rules_inline/links.js
@@ -125,7 +125,9 @@ module.exports = function links(state, silent) {
       label = state.src.slice(labelStart, labelEnd);
     }
 
-    ref = state.env.references[normalizeReference(label)];
+    if (state.env.references) {
+      ref = state.env.references[normalizeReference(label)];
+    }
     if (!ref) {
       state.pos = oldPos;
       return false;


### PR DESCRIPTION
Fixes https://github.com/jonschlinkert/remarkable/issues/325

This is a quick fix to defend against an undefined variable.

Core defines the reference rule, however the inline module references it - I'm sure there's a better way to fix this edge-case but this works too.