### PR TITLE
Bump version of argparse to remove vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "argparse": "~0.1.15",
+    "argparse": "~1.0.10",
     "autolinker": "~0.28.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #310.

It might not work to install dependencies right now due to a problem with the `highlight.js` package -- see also highlightjs/highlight.js#1984. They're working on it, you can explicitly `npm install highlight.js@9.14.2` to work around it for now.