### PR TITLE
Fix build and update node versions to test with

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: false
 language: node_js
 node_js:
   - node
+  - '10'
+  - '8'
   - '6'
+  - '4'
   - '0.10'
   - '0.12'
-  - 4
-  - 6
 script: make test-ci

--- a/package.json
+++ b/package.json
@@ -63,13 +63,18 @@
   },
   "devDependencies": {
     "ansi": "^0.3.0",
+    "autoprefixer-stylus": "^0.3.0",
     "benchmark": "^1.0.0",
+    "browserify": "*",
     "commonmark": "0.12.0",
-    "eslint": "^0.10.1",
-    "gulp-format-md": "^0.1.10",
-    "highlight.js": "^9.7.0",
+    "coveralls": "^2.11.2",
+    "eslint": "0.10.1",
+    "istanbul": "*",
+    "jade": "^1.6.0",
     "marked": "0.3.2",
-    "mocha": "*"
+    "stylus": "^0.49.1",
+    "mocha": "*",
+    "uglify-js": "*"
   },
   "keywords": [
     "commonmark",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "jade": "^1.6.0",
     "marked": "0.3.2",
     "stylus": "^0.49.1",
-    "mocha": "*",
+    "mocha": "3.2.0",
     "uglify-js": "*"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "ansi": "^0.3.0",
     "benchmark": "^1.0.0",
     "commonmark": "0.12.0",
+    "eslint": "^0.10.1",
     "gulp-format-md": "^0.1.10",
     "highlight.js": "^9.7.0",
     "marked": "0.3.2",


### PR DESCRIPTION
I will be looking into fixing #332 next, but I'd like to see a green build as a starting point.

I wasn't sure about the distinction between `master` and `dev`, so I started on `master`. I found the last green build and it was using an pinned `eslint` version - it seems the same version is also pinned on `dev` - I believe #323 has an attempt to upgrade `eslint` to something more modern, but my top priority here is getting rid of the XSS, so maybe some other day :)

I also restored some other deps, that were present in the last green build I could find (https://github.com/jonschlinkert/remarkable/tree/429881961da02f351393050a698c447376df5328).