### PR TITLE
Ignore control chars in links

### DIFF
--- a/lib/helpers/parse_link_destination.js
+++ b/lib/helpers/parse_link_destination.js
@@ -49,7 +49,8 @@ export default function parseLinkDestination(state, pos) {
 
     if (code === 0x20) { break; }
 
-    if (code > 0x08 && code < 0x0e) { break; }
+    // ascii control chars
+    if (code < 0x20 || code === 0x7F) { break; }
 
     if (code === 0x5C /* \ */ && pos + 1 < max) {
       pos += 2;

--- a/test/fixtures/remarkable/xss.txt
+++ b/test/fixtures/remarkable/xss.txt
@@ -77,3 +77,10 @@ javascript:alert(1)
 <p>javascript:alert(1)</p>
 <p>javascript:alert(1)</p>
 .
+
+
+.
+[ASCII control characters XSS](javascript:alert(1))
+.
+<p>[ASCII control characters XSS](javascript:alert(1))</p>
+.


### PR DESCRIPTION
Closes https://github.com/jonschlinkert/remarkable/issues/332

The code here is very similar to other markdown libraries, so I pretty much did what they do:

- https://github.com/npm/marky-markdown/blob/008509231558765695938020a376b5b2e4fd4fcc/lib/gfm/override-link-destination-parser.js#L67
- https://github.com/markdown-it/markdown-it/blob/ba6830ba13fb92953a91fb90318964ccd15b82c4/lib/helpers/parse_link_destination.js#L53

Edit: 26/Jul - rebased and updated the test fixture txt to follow latest practice