### PR TITLE
Prevent a ReDoS vulnerability

### DIFF
--- a/lib/common/html_re.js
+++ b/lib/common/html_re.js
@@ -41,7 +41,7 @@ var close_tag   = /<\/[A-Za-z][A-Za-z0-9]*\s*>/;
 var comment     = /<!--([^-]+|[-][^-]+)*-->/;
 var processing  = /<[?].*?[?]>/;
 var declaration = /<![A-Z]+\s+[^>]*>/;
-var cdata       = /<!\[CDATA\[([^\]]+|\][^\]]|\]\][^>])*\]\]>/;
+var cdata       = /<!\[CDATA\[[\s\S]*?\]\]>/;
 
 export var HTML_TAG_RE = replace(/^(?:open_tag|close_tag|comment|processing|declaration|cdata)/)
   ('open_tag', open_tag)

--- a/lib/common/html_re.js
+++ b/lib/common/html_re.js
@@ -38,7 +38,7 @@ var open_tag    = replace(/<[A-Za-z][A-Za-z0-9]*attribute*\s*\/?>/)
                     ();
 
 var close_tag   = /<\/[A-Za-z][A-Za-z0-9]*\s*>/;
-var comment     = /<!--([^-]+|[-][^-]+)*-->/;
+var comment     = /<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->/;
 var processing  = /<[?].*?[?]>/;
 var declaration = /<![A-Z]+\s+[^>]*>/;
 var cdata       = /<!\[CDATA\[[\s\S]*?\]\]>/;

--- a/test/fixtures/remarkable/redos.txt
+++ b/test/fixtures/remarkable/redos.txt
@@ -3,3 +3,9 @@
 .
 <p><a>ReDoS</a>&lt;![CDATA[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]] &gt;</p>
 .
+
+.
+<a>z</a><!--aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa--->
+.
+<p><a>z</a>&lt;!–aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa—&gt;</p>
+.

--- a/test/fixtures/remarkable/redos.txt
+++ b/test/fixtures/remarkable/redos.txt
@@ -1,0 +1,5 @@
+.
+<a>ReDoS</a><![CDATA[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]] >
+.
+<p><a>ReDoS</a>&lt;![CDATA[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]] &gt;</p>
+.


### PR DESCRIPTION
Closes #331.

Ported from https://github.com/markdown-it/markdown-it/commit/89c8620157d6e38f9872811620d25138fc9d1b0d. The author of the modified file and that commit is the same, so I assume they knew what they were doing.

~~I will remove the merge of #333 once the build is green.~~ Not sure what happened with older nodes, but I won't bother about it right now. Greenish build: https://travis-ci.org/jonschlinkert/remarkable/builds/532349463
