### PR TITLE
Provide commonjs and esm bundles as entry points

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = require('./lib/');

--- a/linkify/package.json
+++ b/linkify/package.json
@@ -1,4 +1,5 @@
 {
   "name": "remarkable/linkify",
-  "main": "../lib/linkify.js"
+  "main": "../dist/cjs/linkify.js",
+  "module": "../dist/esm/linkify.js"
 }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "nyc": {
     "exclude": [
-      "dist/*.js"
+      "dist"
     ]
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "lib"
   ],
   "bin": "./bin/remarkable.js",
-  "main": "./dist/remarkable.cjs.js",
-  "module": "./dist/remarkable.esm.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
   "engines": {
     "node": ">= 0.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -62,6 +62,11 @@
     "test-ci": " make rollup && nyc mocha -r esm -R spec --bail",
     "coverage": "yarn add coveralls@2 && nyc report --reporter=text-lcov | coveralls"
   },
+  "nyc": {
+    "exclude": [
+      "dist/*.js"
+    ]
+  },
   "dependencies": {
     "argparse": "^1.0.10",
     "autolinker": "~0.28.0"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "scripts": {
     "build": "make rollup",
     "test": "make rollup && make test",
-    "test-ci": "nyc mocha -r esm -R spec --bail",
+    "test-ci": " make rollup && nyc mocha -r esm -R spec --bail",
     "coverage": "yarn add coveralls@2 && nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,13 +50,15 @@
     "index.js",
     "lib"
   ],
-  "main": "index.js",
   "bin": "./bin/remarkable.js",
+  "main": "./dist/remarkable.cjs.js",
+  "module": "./dist/remarkable.esm.js",
   "engines": {
     "node": ">= 0.10.0"
   },
   "scripts": {
-    "test": "make test",
+    "build": "make rollup",
+    "test": "make rollup && make test",
     "test-ci": "nyc mocha -r esm -R spec --bail",
     "coverage": "yarn add coveralls@2 && nyc report --reporter=text-lcov | coveralls"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,6 @@ import path from 'path';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
-import pkg from './package.json';
 
 const name = 'Remarkable';
 const external = id => !id.startsWith('.') && !path.isAbsolute(id);
@@ -10,7 +9,7 @@ const external = id => !id.startsWith('.') && !path.isAbsolute(id);
 export default [
   {
     input: ['./lib/index.js', './lib/linkify.js'],
-    output: { file: 'dist/cjs', format: 'cjs' },
+    output: { dir: 'dist/cjs', format: 'cjs' },
     external,
     plugins: [
       commonjs(),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,10 +1,31 @@
+import path from 'path';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import { terser } from 'rollup-plugin-terser';
+import pkg from './package.json';
 
 const name = 'Remarkable';
+const external = id => !id.startsWith('.') && !path.isAbsolute(id);
 
 export default [
+  {
+    input: ['./lib/index.js', './lib/linkify.js'],
+    output: { file: 'dist/cjs', format: 'cjs' },
+    external,
+    plugins: [
+      commonjs(),
+    ]
+  },
+
+  {
+    input: ['./lib/index.js', './lib/linkify.js'],
+    output: { dir: 'dist/esm', format: 'esm' },
+    external,
+    plugins: [
+      commonjs(),
+    ]
+  },
+
   {
     input: './lib/umd.js',
     output: { file: 'dist/remarkable.js', format: 'umd', name },
@@ -13,6 +34,7 @@ export default [
       commonjs(),
     ]
   },
+
   {
     input: './lib/umd.js',
     output: { file: 'dist/remarkable.min.js', format: 'umd', name },

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,5 +1,5 @@
-const ChildProcess = require("child_process")
-var assert = require('assert');
+import ChildProcess from "child_process";
+import assert from 'assert';
 
 // placed here to make multiline indentation easier, feel free to move if you're
 // adding more tests here


### PR DESCRIPTION
In this diff I replaced lib entry point with bundled chunks

package.json
main: ./dist/cjs/index.js
module: ./dist/esm/index.js

linkify/package.json
main: ../dist/cjs/linkify.js
module: ../dist/esm/linkify.js

lib will be rewritten with esm.

Bundles has a few benefits
- faster startup time in node
- faster bundling
- internals are hidden and changing them will not affect users
- anything reused between remarkable and linkify plugin will be splitted into chunks and imported by both index.js and linkify.js so user will not get any duplication

UMD is packed into single bundle as before