### PR TITLE
Use named exports for public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,8 +293,8 @@ plugins.
 Autoconvert URL-like text to links
 
 ```js
-import Remarkable from 'remarkable';
-import linkify from 'remarkable/linkify';
+import { Remarkable } from 'remarkable';
+import { linkify } from 'remarkable/linkify';
 
 var md = new Remarkable().use(linkify);
 ```

--- a/README.md
+++ b/README.md
@@ -33,12 +33,23 @@ npm install remarkable --save
 ## Usage
 
 ```js
-var Remarkable = require('remarkable');
+import { Remarkable } from 'remarkable';
 var md = new Remarkable();
 
 console.log(md.render('# Remarkable rulezz!'));
 // => <h1>Remarkable rulezz!</h1>
 ```
+
+or with commonjs
+
+```js
+const { Remarkable } = require('remarkable');
+var md = new Remarkable();
+
+console.log(md.render('# Remarkable rulezz!'));
+// => <h1>Remarkable rulezz!</h1>
+```
+
 
 If installed globally with `npm`:
 
@@ -101,7 +112,8 @@ console.log(md.render('# Remarkable rulezz!'));
 Or define options via the `.set()` method:
 
 ```js
-var Remarkable = require('remarkable');
+import { Remarkable } 'remarkable';
+
 var md = new Remarkable();
 
 md.set({
@@ -126,7 +138,7 @@ active syntax rules and options for common use cases.
 Enable strict [CommonMark](http://commonmark.org/) mode with the `commonmark` preset:
 
 ```js
-var Remarkable = require('remarkable');
+import { Remarkable } from 'remarkable';
 var md = new Remarkable('commonmark');
 ```
 
@@ -135,7 +147,7 @@ var md = new Remarkable('commonmark');
 Enable all available rules (but still with default options, if not set):
 
 ```js
-var Remarkable = require('remarkable');
+import { Remarkable } from 'remarkable';
 var md = new Remarkable('full');
 
 // Or with options:
@@ -151,8 +163,8 @@ var md = new Remarkable('full', {
 Apply syntax highlighting to fenced code blocks with the `highlight` option:
 
 ```js
-var Remarkable = require('remarkable');
-var hljs       = require('highlight.js') // https://highlightjs.org/
+import { Remarkable } from 'remarkable';
+import hljs from 'highlight.js' // https://highlightjs.org/
 
 // Actual default values
 var md = new Remarkable({
@@ -233,7 +245,7 @@ Although full-weight typographical replacements are language specific, `remarkab
 provides coverage for the most common and universal use cases:
 
 ```js
-var Remarkable = require('remarkable');
+import { Remarkable } from 'remarkable';
 var md = new Remarkable({
   typographer: true,
   quotes: '“”‘’'
@@ -285,6 +297,14 @@ import Remarkable from 'remarkable';
 import linkify from 'remarkable/linkify';
 
 var md = new Remarkable().use(linkify);
+```
+
+### UMD
+
+UMD bundle provides linkify out of the box
+
+```js
+const { Remarkable, linkify, utils } = window.remarkable;
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ console.log(md.render('# Remarkable rulezz!'));
 Or define options via the `.set()` method:
 
 ```js
-import { Remarkable } 'remarkable';
+import { Remarkable } from 'remarkable';
 
 var md = new Remarkable();
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import argparse from 'argparse';
-import Remarkable from './index';
-import linkify from './linkify';
+import { Remarkable } from './index';
+import { linkify } from './linkify';
 import { version } from '../package.json';
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,15 @@ import fullConfig from './configs/full';
 import commonmarkConfig from './configs/commonmark';
 
 /**
+ * Expose `utils`, Useful helper functions for custom
+ * rendering.
+ */
+
+export {
+  utils
+}
+
+/**
  * Preset configs
  */
 
@@ -47,7 +56,7 @@ function StateCore(instance, str, env) {
  * @param {Object} `options`
  */
 
-export default function Remarkable(preset, options) {
+export function Remarkable(preset, options) {
   if (typeof preset !== 'string') {
     options = preset;
     preset = 'default';
@@ -186,10 +195,3 @@ Remarkable.prototype.renderInline = function (str, env) {
   env = env || {};
   return this.renderer.render(this.parseInline(str, env), this.options, env);
 };
-
-/**
- * Expose `utils`, Useful helper functions for custom
- * rendering.
- */
-
-Remarkable.utils = utils;

--- a/lib/linkify.js
+++ b/lib/linkify.js
@@ -156,6 +156,6 @@ function parseTokens(state) {
   }
 };
 
-export default function linkify(md) {
+export function linkify(md) {
   md.core.ruler.push('linkify', parseTokens);
 };

--- a/lib/umd.js
+++ b/lib/umd.js
@@ -1,6 +1,2 @@
-import Remarkable from './index';
-import linkify from './linkify';
-
-Remarkable.linkify = linkify;
-
-export default Remarkable;
+export { Remarkable, utils } from './index';
+export { linkify } from './linkify';

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@ import commonjs from 'rollup-plugin-commonjs';
 import json from 'rollup-plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
-const name = 'Remarkable';
+const name = 'remarkable';
 const external = id => !id.startsWith('.') && !path.isAbsolute(id);
 
 export default [

--- a/support/specsplit.js
+++ b/support/specsplit.js
@@ -7,7 +7,7 @@
 import fs from 'fs';
 import util from 'util';
 import argparse from 'argparse';
-import Remarkable from '../lib/index.js';
+import { Remarkable } from '../lib/index.js';
 import pkg from '../package.json';
 
 var cli = new argparse.ArgumentParser({

--- a/test/commonmark.js
+++ b/test/commonmark.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { addTests } from './utils';
-import Remarkable from '../lib/index';
+import { Remarkable } from '../lib/index';
 
 describe('CommonMark', function () {
   var md = new Remarkable('commonmark');

--- a/test/linkify.js
+++ b/test/linkify.js
@@ -1,8 +1,8 @@
 import path from 'path';
 import assert from 'assert';
 import { addTests } from './utils';
-import Remarkable from '../lib/index';
-import linkify from '../lib/linkify';
+import { Remarkable } from '../lib/index';
+import { linkify } from '../lib/linkify';
 
 describe('linkify plugin', function () {
   var md = new Remarkable({ html: true }).use(linkify);

--- a/test/misc.js
+++ b/test/misc.js
@@ -1,8 +1,6 @@
 import assert from 'assert';
-import Remarkable from '../lib/index';
-import linkify from '../lib/linkify';
-
-const { utils } = Remarkable
+import { Remarkable, utils } from '../lib/index';
+import { linkify } from '../lib/linkify';
 
 
 describe('Utils', function () {

--- a/test/remarkable.js
+++ b/test/remarkable.js
@@ -1,6 +1,6 @@
 import path from 'path';
 import { addTests } from './utils';
-import Remarkable from '../lib/index';
+import { Remarkable } from '../lib/index';
 
 describe('remarkable', function () {
   var md = new Remarkable('full', {


### PR DESCRIPTION
Default exports are always a headache for public api. They are hard to
use when same module is used for both node and webpack via commonjs.
We have this problem

https://github.com/webpack/webpack/issues/6584

Mixing named and default exports works even buggier.

https://github.com/webpack/webpack/issues/7973

The best solution is using only named exports. They fits perfectly with
interops and may work without interop for commonjs.

(module.exports = was a mistake, export default IMO too)