### PR TITLE
Add language class to <pre> tags for Prism compatibility

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -67,7 +67,7 @@ rules.fence = function(tokens, idx, options, env, instance) {
     highlighted = escapeHtml(token.content);
   }
 
-  return '<pre><code' + langClass + '>'
+  return '<pre' + langClass + '><code' + langClass + '>'
         + highlighted
         + '</code></pre>'
         + getBreak(tokens, idx);

--- a/test/fixtures/commonmark/good.txt
+++ b/test/fixtures/commonmark/good.txt
@@ -1162,7 +1162,7 @@ def foo(x)
 end
 ```
 .
-<pre><code class="language-ruby">def foo(x)
+<pre class="language-ruby"><code class="language-ruby">def foo(x)
   return 3
 end
 </code></pre>
@@ -1178,7 +1178,7 @@ def foo(x)
 end
 ~~~~~~~
 .
-<pre><code class="language-ruby startline=3 $%@#$ ruby-example">def foo(x)
+<pre class="language-ruby startline=3 $%@#$ ruby-example"><code class="language-ruby startline=3 $%@#$ ruby-example">def foo(x)
   return 3
 end
 </code></pre>
@@ -1191,7 +1191,7 @@ src line: 1430
 ````;
 ````
 .
-<pre><code class="language-;"></code></pre>
+<pre class="language-;"><code class="language-;"></code></pre>
 .
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -3288,7 +3288,7 @@ src line: 3929
 foo
 ```
 .
-<pre><code class="language-foo+bar">foo
+<pre class="language-foo+bar"><code class="language-foo+bar">foo
 </code></pre>
 .
 
@@ -3383,7 +3383,7 @@ src line: 4040
 foo
 ```
 .
-<pre><code class="language-föö">foo
+<pre class="language-föö"><code class="language-föö">foo
 </code></pre>
 .
 

--- a/test/fixtures/commonmark/spec.txt
+++ b/test/fixtures/commonmark/spec.txt
@@ -1408,7 +1408,7 @@ def foo(x)
 end
 ```
 .
-<pre><code class="language-ruby">def foo(x)
+<pre class="language-ruby"><code class="language-ruby">def foo(x)
   return 3
 end
 </code></pre>
@@ -1421,7 +1421,7 @@ def foo(x)
 end
 ~~~~~~~
 .
-<pre><code class="language-ruby">def foo(x)
+<pre class="language-ruby"><code class="language-ruby">def foo(x)
   return 3
 end
 </code></pre>
@@ -1431,7 +1431,7 @@ end
 ````;
 ````
 .
-<pre><code class="language-;"></code></pre>
+<pre class="language-;"><code class="language-;"></code></pre>
 .
 
 Info strings for backtick code blocks cannot contain backticks:
@@ -3931,7 +3931,7 @@ blocks](#fenced-code-block):
 foo
 ```
 .
-<pre><code class="language-foo+bar">foo
+<pre class="language-foo+bar"><code class="language-foo+bar">foo
 </code></pre>
 .
 


### PR DESCRIPTION
I'm using Docusaurus, which uses Remarkable under-the-hood. Its default highlighter is higlight.js, but I wanted to use Prism instead.

Prism almost works, the only hiccup is that Prism CSS requires `<pre>` tags to have the `language-*` class. Since I didn't have much luck figuring out how to create a plugin for this, I thought we could make this built-in. This is what this PR does.