### PR TITLE
Correctly identify Ellipsis as 3 dots

### DIFF
--- a/lib/rules_core/replacements.js
+++ b/lib/rules_core/replacements.js
@@ -46,7 +46,7 @@ export default function replace(state) {
             .replace(/\+-/g, '±')
             // .., ..., ....... -> …
             // but ?..... & !..... -> ?.. & !..
-            .replace(/\.{2,}/g, '…').replace(/([?!])…/g, '$1..')
+            .replace(/\.{3,}/g, '…').replace(/([?!])…/g, '$1..')
             .replace(/([?!]){4,}/g, '$1$1$1').replace(/,{2,}/g, ',')
             // em-dash
             .replace(/(^|[^-])---([^-]|$)/mg, '$1\u2014$2')


### PR DESCRIPTION
To the best of my knowledge and exploration, Ellipsis consists of 3 dots (...) not 2. This bug is causing issues where consumers are trying to read format examples and getting it wrong in a downstream tool ([swagger-ui](https://github.com/swagger-api/swagger-ui)) that consumes this library. Rather than loosing all of the other auto-formatting to work around a bug, I'd rather see it fixed as the source.

Yes, this would be a breaking change for existing users, but I understand that common-mark does it right, and that the correct format to get an ellipsis is to use 3 dots, anyway. I believe this implementation using two dots therefore to be a legit bug :)

[working example in commonmark](https://spec.commonmark.org/dingus/?text=2019-01..2020-10%0A%0A2019-01...2020-10&smart=1)