### PR TITLE
fix: fix vertical bar within backtick within a table not escape issue

### DIFF
--- a/lib/rules_block/table.js
+++ b/lib/rules_block/table.js
@@ -106,6 +106,45 @@ export default function table(state, startLine, endLine, silent) {
 
     lineText = getLine(state, nextLine).trim();
     if (lineText.indexOf('|') === -1) { break; }
+
+    // fix vertical bar within backtick within a table not escape issue
+    // e.g. | `a | b` | => | <code>a &#124; b</code> | 
+    var inBacktickBlock = false
+    var lineTextCurArray = []
+    var lineTextCharArray = lineText.split('')
+
+    lineTextCharArray.forEach(function(item, index){
+      // first | char
+      if (index === 0 && item === '|') return lineTextCurArray.push(item)
+      // last | char
+      if (index === lineTextCharArray.length - 1 && item === '|') return lineTextCurArray.push(item)
+      
+      // in backtick block
+      if (item === '`') {
+        if (inBacktickBlock) {
+          inBacktickBlock = false
+          lineTextCurArray.push('</code>')
+        } else {
+          inBacktickBlock = true
+          lineTextCurArray.push('<code>')
+        }
+        return
+      }
+
+      if (item === '|') {
+        if (inBacktickBlock) {
+          lineTextCurArray.push('&#124;')
+          return
+        } else {
+          lineTextCurArray.push(item)
+          return
+        }
+      }
+
+      lineTextCurArray.push(item)
+    })
+
+    lineText = lineTextCurArray.join('')
     rows = lineText.replace(/^\||\|$/g, '').split('|');
 
     state.tokens.push({ type: 'tr_open', level: state.level++ });

--- a/test/fixtures/remarkable/tables.txt
+++ b/test/fixtures/remarkable/tables.txt
@@ -127,3 +127,23 @@ Minimal one-column table test:
 </tbody>
 </table>
 .
+
+escape `|` char within backtick within table test:
+
+.
+| foo | bar |
+| --- | --- |
+| `a | b` | `a || b` |
+| a | b |
+
+.
+<table>
+<thead>
+<tr><th>foo</th><th>bar</th></tr>
+</thead>
+<tbody>
+<tr><td><code>a | b</code></td><td><code>a || b</code></td></tr>
+<tr><td>a</td><td>b</td></tr>
+</tbody>
+</table>
+.


### PR DESCRIPTION
fix vertical bar within backtick within a table not escape issue