### PR TITLE
Fix security flaw when linkTarget option contains _blank

### DIFF
--- a/lib/rules.js
+++ b/lib/rules.js
@@ -146,8 +146,10 @@ rules.paragraph_close = function(tokens, idx /*, options, env */) {
  */
 
 rules.link_open = function(tokens, idx, options /* env */) {
+  var linkTarget = options.linkTarget;
   var title = tokens[idx].title ? (' title="' + escapeHtml(replaceEntities(tokens[idx].title)) + '"') : '';
-  var target = options.linkTarget ? (' target="' + options.linkTarget + '"') : '';
+  var rel = linkTarget && linkTarget.indexOf('_blank') !== -1 ? ' rel="noopener noreferrer"' : '';
+  var target = linkTarget ? (' target="' + options.linkTarget + '"' + rel) : '';
   return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + '>';
 };
 rules.link_close = function(/* tokens, idx, options, env */) {

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -146,11 +146,13 @@ rules.paragraph_close = function(tokens, idx /*, options, env */) {
  */
 
 rules.link_open = function(tokens, idx, options /* env */) {
-  var linkTarget = options.linkTarget;
   var title = tokens[idx].title ? (' title="' + escapeHtml(replaceEntities(tokens[idx].title)) + '"') : '';
+  
+  var linkTarget = options.linkTarget;
+  var target = linkTarget ? (' target="' + options.linkTarget + '"') : '';
   var rel = linkTarget && linkTarget.indexOf('_blank') !== -1 ? ' rel="noopener noreferrer"' : '';
-  var target = linkTarget ? (' target="' + options.linkTarget + '"' + rel) : '';
-  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + '>';
+
+  return '<a href="' + escapeHtml(tokens[idx].href) + '"' + title + target + rel + '>';
 };
 rules.link_close = function(/* tokens, idx, options, env */) {
   return '</a>';


### PR DESCRIPTION
https://web.dev/external-anchors-use-rel-noopener/

Or should I just add a `linkRel` option ?
It might be useful to make the links `nofollow`