### PR TITLE
Checkbox / tasklist support

### DIFF
--- a/lib/parser_inline.js
+++ b/lib/parser_inline.js
@@ -24,6 +24,7 @@ var _rules = [
   [ 'sub',             require('./rules_inline/sub') ],
   [ 'sup',             require('./rules_inline/sup') ],
   [ 'links',           require('./rules_inline/links') ],
+  [ 'checkbox',        require('./rules_inline/checkbox') ],
   [ 'footnote_inline', require('./rules_inline/footnote_inline') ],
   [ 'footnote_ref',    require('./rules_inline/footnote_ref') ],
   [ 'autolink',        require('./rules_inline/autolink') ],

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -164,6 +164,13 @@ rules.link_close = function (/* tokens, idx, options, env */) {
 };
 
 /**
+ * Checkbox
+ */
+rules.checkbox = function (tokens, idx /*, options, env */) {
+  return '<input type="checkbox" disabled class="checkbox-item"' + (tokens[idx].checked ? ' checked' : '') + '>';
+};
+
+/**
  * Images
  */
 

--- a/lib/rules_inline/checkbox.js
+++ b/lib/rules_inline/checkbox.js
@@ -1,0 +1,39 @@
+// Process [x] Checkboxes
+
+'use strict';
+
+module.exports = function links(state /*, silent */) {
+  var pos = state.pos;
+  var maxpos = state.posMax;
+  if (pos === maxpos) {
+    return false;
+  }
+  if (state.src.charCodeAt(pos) !== 91) {
+    return false;
+  }
+  ++pos;
+  if (state.src.charCodeAt(pos) === 93) {
+    state.push({
+      type: 'checkbox',
+      checked: false,
+      level: state.level
+    });
+    state.pos = pos + 1;
+    return true;
+  }
+  if (state.src.charCodeAt(pos) === 120 || state.src.charCodeAt(pos) === 88 || state.src.charCodeAt(pos) === 32) {
+    var checked = (state.src.charCodeAt(pos) !== 32);
+    ++pos;
+    if (state.src.charCodeAt(pos) !== 93) {
+      return false;
+    }
+    state.push({
+      type: 'checkbox',
+      checked: checked,
+      level: state.level
+    });
+    state.pos = pos + 1;
+    return true;
+  }
+  return false;
+};

--- a/test/fixtures/remarkable/checkbox.txt
+++ b/test/fixtures/remarkable/checkbox.txt
@@ -1,0 +1,6 @@
+[x] Checked
+[ ] Not checked
+
+# List
+- [ ] Not checked
+- [x] Checked


### PR DESCRIPTION
Supports adding checkboxes to markdown:
```
- [x] Checked
- [ ] Not checked
```

- [x] Checked
- [ ] Not checked

Code modified from [here](https://github.com/jonschlinkert/remarkable/issues/189#issuecomment-590026524).