### PR TITLE
linkify: allows for URL text shortening

### DIFF
--- a/lib/linkify.js
+++ b/lib/linkify.js
@@ -113,7 +113,7 @@ function parseTokens(state) {
 
           if (!state.inline.validateLink(links[ln].url)) { continue; }
 
-          pos = text.indexOf(links[ln].text);
+          pos = text.indexOf(links[ln].url);
 
           if (pos) {
             nodes.push({
@@ -137,7 +137,7 @@ function parseTokens(state) {
             type: 'link_close',
             level: --level
           });
-          text = text.slice(pos + links[ln].text.length);
+          text = text.slice(pos + links[ln].url.length);
         }
         if (text.length) {
           nodes.push({


### PR DESCRIPTION
This allows to change `replaceFn` in `Autolinker` to something like this:

```js
replaceFn : function (match) {
	switch (match.getType()) {
		case 'url':
			// here's the change..
			let text = match.matchedText;

			if (text.length > 25) {
				text = text.substr(0, 23) + "..";
			}

			links.push({
				text: text,
				url: match.getUrl()
			});
			break;
		case 'email':
			links.push({
				text: match.matchedText,
				// normalize email protocol
				url: 'mailto:' + match.getEmail().replace(/^mailto:/i, '')
			});
			break;
	}
	return false;
}
```