### PR TITLE
Upgrade autolinker

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "dependencies": {
     "argparse": "^1.0.10",
-    "autolinker": "^3.11.0"
+    "autolinker": "^4.0.0"
   },
   "devDependencies": {
     "ansi": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "remarkable",
   "description": "Markdown parser, done right. 100% Commonmark support, extensions, syntax plugins, high speed - all in one.",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "homepage": "https://github.com/jonschlinkert/remarkable",
   "maintainers": [
     "doowb <brian.woodward@sellside.com>",

--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
   "scripts": {
     "build": "rm -rf dist && yarn rollup -c",
     "lint": "eslint .",
-    "test:browser": "yarn build && node -r esm ./test/test-browser.js && serve .",
-    "test:spec": "./support/specsplit.js test/fixtures/commonmark/spec.txt",
+    "test:browser": "yarn build && yarn node -r esm ./test/test-browser.js && serve .",
+    "test:spec": "yarn node -r esm ./support/specsplit.js ./test/fixtures/commonmark/spec.txt",
     "test:mocha": "mocha -r esm -R spec",
     "test:ci": "nyc mocha -r esm -R spec --bail",
     "test": "yarn test:mocha && yarn test:spec",

--- a/support/specsplit.js
+++ b/support/specsplit.js
@@ -1,4 +1,3 @@
-#!/usr/bin/env node -r esm
 /*eslint no-console:0*/
 
 // Fixtures generator from commonmark specs. Split spec to working / not working

--- a/test/fixtures/linkify.txt
+++ b/test/fixtures/linkify.txt
@@ -38,14 +38,6 @@ www.example.org
 .
 
 
-properly cut domain end
-.
-www.example.org版权所有
-.
-<p><a href="http://www.example.org版权所有">www.example.org版权所有</a></p>
-.
-
-
 unicode
 .
 www.example.org#版权所有

--- a/test/test-browser.js
+++ b/test/test-browser.js
@@ -9,8 +9,8 @@ const readFixtureDir = dir =>
 
 const content = `
 <script type="module">
-  import RemarkableWithMap from './dist/esm/index.js';
-  import RemarkableWithTextarea from './dist/esm/index.browser.js';
+  import { Remarkable as RemarkableWithMap } from './dist/esm/index.browser.js';
+  import { Remarkable as RemarkableWithTextarea } from './dist/esm/index.browser.js';
 
   const markdownWithMap = new RemarkableWithMap('commonmark');
   const markdownWithTextarea = new RemarkableWithMap('commonmark');

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,12 +261,12 @@ atob@^2.1.1:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-autolinker@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-3.11.0.tgz#209c4632550eed32285058eaac51f1382dae023a"
-  integrity sha512-VMTEjE3jeBK5MinTZiuVE07O4wMVmXhpzmc5sCc8cap6exsVzjmQJgtH8NqHsFru58ujUieBA9Dmwiz+E5KWEA==
+autolinker@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/autolinker/-/autolinker-4.0.0.tgz#aa1f9a52786b727b0ecee8cd7d4a97e0e3ef59f1"
+  integrity sha512-fl5Kh6BmEEZx+IWBfEirnRUU5+cOiV0OK7PEt0RBKvJMJ8GaRseIOeDU3FKf4j3CE5HVefcjHmhYPOcaVt0bZw==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.3.0"
 
 autolinker@~0.15.0:
   version "0.15.3"
@@ -2835,10 +2835,15 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.3.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@~0.3.2:
   version "0.3.2"


### PR DESCRIPTION
This PR upgrades the autolinker dependency in order to avoid depending on the vulnerable version which still used the `gulp-header` dependency which itself has a vulnerable dependency.